### PR TITLE
Leseberechtigung des Turnierreports festgelegt

### DIFF
--- a/logic/turnier_report.logic.php
+++ b/logic/turnier_report.logic.php
@@ -9,6 +9,16 @@ if ($turnier->details['ausrichter'] == ($_SESSION['logins']['team']['id'] ?? '')
     $change_tbericht = false;
 }
 
+$anmeldungen = $turnier->get_anmeldungen();
+$spielen_liste = $anmeldungen['spiele'];
+
+$lese_berechtigung = false;
+foreach ($spielen_liste as $team) {
+    if (($team['team_id'] == ($_SESSION['logins']['team']['id'] ?? '')) || Helper::$ligacenter) {
+        $lese_berechtigung = true;
+    }
+}
+
 if (strtotime($turnier->details['datum']) - time() < -3 * 24 * 60 * 60 && !Helper::$ligacenter) {
     $change_tbericht = false; //Berechtigung zum Verändern des Reports widerrufen für Ausrichter, wenn das Turnier mehr als zwei Tage zurückliegt.
     if ($turnier->details['ausrichter'] == ($_SESSION['logins']['team']['id'] ?? '')) {
@@ -25,6 +35,14 @@ if (empty($turnier->details)) {
     die();
 }
 
+// Gibt es eine Leseberechtigung?
+if (!$lese_berechtigung) {
+    Html::notice("Der Turnierreport kann nur von teilnehmenden Teams eingesehen werden.");
+    header('Location: ../liga/turnier_details.php?turnier_id=' . $turnier->id);
+    die();
+}
+
+// Ist es ein Spass-Turnier?
 if ($turnier->details['art'] == 'spass') {
     Html::notice("Spaßturniere erfordern keinen Turnierreport.");
     header('Location: ../liga/turnier_details.php?turnier_id=' . $turnier->id);

--- a/templates/turnier_report.tmp.php
+++ b/templates/turnier_report.tmp.php
@@ -6,7 +6,7 @@
     <?= Html::icon('article', tag:'h2') ?> Turnier-Report
 </h2>
 <?php Html::message('notice',
-            "Der Turnierreport ist nur von andere Ligateams und dem Ligaausschuss einsehbar.",
+            "Der Turnierreport ist nur von teilnehemenden Ligateams und dem Ligaausschuss einsehbar.",
             "") ?>
 <!-- Link Spielplan -->
 <p><?=Html::link('../liga/spielplan.php?turnier_id=' . $turnier_id, '<i class="material-icons">reorder</i> Zum Spielplan')?></p>


### PR DESCRIPTION
Lösung für #54

So umgesetzt, dass nur die Teams der Spielen-Liste einen Zugriff erhalten.
Wenn sie auf einer anderen oder gar keiner Liste sitzen, werden sie mit entsprechenden Hinweis auf die Detail-Seite weitergeleitet.