### PR TITLE
Überarbeitung der Grid-Darstellung in den Centern

### DIFF
--- a/classes/nav.class.php
+++ b/classes/nav.class.php
@@ -123,7 +123,7 @@ class Nav
      */
     public static function get_lc_start(): array
     {
-        return [
+        return array(
             [Env::BASE_URL . "/ligacenter/lc_abstimmung.php", "Abstimmung", "w3-secondary"],
             [Env::BASE_URL . "/schiricenter/schiritest_erstellen.php", "Schiritest", "w3-secondary"],
             [Env::BASE_URL . "/ligacenter/lc_turnierliste.php", "Turniere verwalten", "w3-primary"],
@@ -140,8 +140,23 @@ class Nav
             [Env::BASE_URL . "/ligacenter/lc_pw_aendern.php", "Passwort ändern", "w3-grey"],
             [Env::BASE_URL . "/ligacenter/lc_admin.php", "Admin", "w3-grey"],
             [Env::BASE_URL . "/ligacenter/lc_checkmail.php", "Mail-Bot", "w3-blue"],
-            [Env::BASE_URL . "/ligacenter/lc_logout.php", "Logout", "w3-grey"]
-        ];
+            [Env::BASE_URL . "/ligacenter/lc_logout.php", "Logout", "w3-grey"],
+        );
+    }
+
+    /**
+     * Downloadlinks für die Startseite des Ligacenters
+     * 
+     * @return string[][]
+     */
+    public static function get_lc_downloads(): array
+    {
+        return array(
+            [Env::BASE_URL . "/ligacenter/lc_turnierstats.php", "turniere.xlsx", "w3-light-grey"],
+            [Env::BASE_URL . "/ligacenter/lc_spielerstats.php", "spieler.xlsx", "w3-light-grey"],
+            [Env::BASE_URL . "/ligacenter/lc_teamstats.php", "teams.xlsx", "w3-light-grey"],
+            [Env::BASE_URL . "/schiricenter/schiritest_stats.php", "schiritest.xlsx", "w3-light-grey"],
+        );
     }
 
     /**
@@ -151,9 +166,9 @@ class Nav
      */
     public static function get_tc_start(): array
     {
-        $links = [
+        $links = array(
             [Env::BASE_URL . "/teamcenter/tc_terminseite_erstellen.php", "Teamtermine", "w3-green"],
-            [Env::BASE_URL . "/teamcenter/tc_turnierliste_anmelden.php", "Turnier- anmeldung", "w3-primary"],
+            [Env::BASE_URL . "/teamcenter/tc_turnierliste_anmelden.php", "Turnieranmeldung", "w3-primary"],
             [Env::BASE_URL . "/teamcenter/tc_turnier_erstellen.php", "Turnier erstellen", "w3-primary"],
             [Env::BASE_URL . "/teamcenter/tc_turnierliste_verwalten.php", "Eigene Turniere", "w3-primary"],
             [Env::BASE_URL . "/teamcenter/tc_neuigkeit_eintragen.php", "Neuigkeiten eintragen", "w3-tertiary"],
@@ -164,7 +179,7 @@ class Nav
             [Env::BASE_URL . "/teamcenter/tc_antrag.php", "Fördermittel", "w3-purple"],
             [Env::BASE_URL . "/teamcenter/tc_pw_aendern.php", "Passwort ändern", "w3-grey"],
             [Env::BASE_URL . "/teamcenter/tc_logout.php", "Logout", "w3-grey"],
-        ];
+        );
         // Abstimmung Finalart
 //        if (Abstimmung::darf_abstimmen($_SESSION['logins']['team']['id'])) {
 //            array_unshift(
@@ -220,12 +235,12 @@ class Nav
 
     public static function get_oc_start(): array
     {
-        return [
+        return array(
             [Env::BASE_URL . "/oefficenter/oc_kontaktcenter.php", "Kontaktcenter", "w3-tertiary"],
             [Env::BASE_URL . "/oefficenter/oc_neuigkeit_eintragen.php", "Neuigkeit eintragen", "w3-tertiary"],
             [Env::BASE_URL . "/liga/neues.php", "Neuigkeit bearbeiten", "w3-tertiary"],
             [Env::BASE_URL . "/oefficenter/oc_pw_aendern.php", "Passwort ändern", "w3-grey"],
-            [Env::BASE_URL . "/oefficenter/oc_logout.php", "Logout", "w3-grey"]
-        ];
+            [Env::BASE_URL . "/oefficenter/oc_logout.php", "Logout", "w3-grey"],
+        );
     }
 }

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -99,3 +99,24 @@ input[type=number] {
 .w3-tertiary,.w3-hover-tertiary:hover{color:#000000!important;background-color:#EAB42E!important}
 .w3-text-tertiary,.w3-hover-text-tertiary:hover{color:#EAB42E!important}
 .w3-border-tertiary,.w3-hover-border-tertiary:hover{border-color:#EAB42E!important}
+
+/* Grid-Darstellung in den Centern */
+.flex-container {
+  display: flex;
+  flex-flow: row wrap;
+  justify-content: space-between;
+  padding-top: 15px;
+  padding-bottom: 15px;
+}
+
+.flex-item {
+  width: 20%;
+  min-height: 100px;
+  min-width: 130px;
+  margin: 10px;
+  padding: 10px;
+  text-align: center;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}

--- a/public/ligacenter/lc_start.php
+++ b/public/ligacenter/lc_start.php
@@ -5,49 +5,29 @@
 require_once '../../init.php';
 require_once '../../logic/session_la.logic.php'; //auth
 
-$centerpanels = Nav::get_lc_start();
+$panels = Nav::get_lc_start();
+$downloads = Nav::get_lc_downloads();
 
 /////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////LAYOUT///////////////////////////////////
 /////////////////////////////////////////////////////////////////////////////
-Html::$page_width = "660px";
 include '../../templates/header.tmp.php'; ?>
 
-
 <h1 class='w3-center w3-text-primary'>Hallo <?= LigaLeitung::get_details($_SESSION['logins']['la']['login'])['vorname'] ?>!</h1>
-<?= Html::link(Env::BASE_URL . "/ligacenter/lc_turnierstats.php", "turniere.xlsx", extern: true) ?>
-<br>
-<?= Html::link(Env::BASE_URL . "/ligacenter/lc_spielerstats.php","spieler.xlsx", extern: true) ?>
-<br>
-<?= Html::link(Env::BASE_URL . "/ligacenter/lc_teamstats.php", "teams.xlsx", extern: true) ?>
-<br>
-<?= Html::link(Env::BASE_URL . "/schiricenter/schiritest_stats.php", "schiritest.xlsx", extern: true) ?>
-<br>
+<div class="flex-container">
+    <?php foreach ($panels as $panel): ?>
+        <a class="no flex-item <?= $panel[2] ?> w3-round-xlarge w3-hover-opacity" href="<?= $panel[0] ?>">
+            <?= $panel[1] ?>
+        </a>
+    <?php endforeach; ?>
+</div>
 
-<div id="messen" class="">
-    <!-- Misst die Fensterbreite des Browsers, um die Centerpanels gleichmäßig verteilen zu können -->
-    <div id="apps" class="w3-content">
-        <div class="w3-row">
-
-            <?php foreach ($centerpanels as $centerpanel) { ?>
-                <a class="" href="<?= $centerpanel[0] ?>">
-                    <div class="w3-col <?= $centerpanel[2] ?> w3-round-xxlarge w3-hover-opacity w3-display-container centerpanels">
-                        <div class="w3-display-middle w3-large w3-center">
-                            <?= $centerpanel[1] ?>
-                        </div>
-                    </div>
-                </a>
-            <?php } //end foreach?>
-
-        </div> <!-- w3-row -->
-    </div> <!-- w3-apps -->
-</div> <!-- w3-messen -->
-
-<script>
-    //setzt die Margin der centerpanels-Quadrate so, dass sie immer gleich verteilt sind
-    window.addEventListener("resize", centerpanels_anordnung);
-    centerpanels_anordnung();
-</script>
+<div class="flex-container w3-border-top w3-border-grey">
+    <?php foreach ($downloads as $download): ?>
+        <a class="no flex-item <?= $download[2] ?> w3-round-xlarge w3-hover-opacity" href="<?= $download[0] ?>">
+            <?= $download[1] ?>
+        </a>
+    <?php endforeach; ?>
+</div>
 
 <?php include '../../templates/footer.tmp.php'; ?>
-

--- a/public/oefficenter/oc_start.php
+++ b/public/oefficenter/oc_start.php
@@ -5,41 +5,20 @@
 require_once '../../init.php';
 require_once '../../logic/session_oa.logic.php'; //auth
 
-$centerpanels = Nav::get_oc_start();
+$panels = Nav::get_oc_start();
 
 /////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////LAYOUT///////////////////////////////////
 /////////////////////////////////////////////////////////////////////////////
-Html::$page_width = "660px";
 include '../../templates/header.tmp.php'; ?>
 
-
 <h1 class='w3-center w3-text-primary'>Hallo <?= LigaLeitung::get_details($_SESSION['logins']['oa']['login'])['vorname'] ?>!</h1>
-
-<div id="messen" class="">
-    <!-- Misst die Fensterbreite des Browsers, um die Centerpanels gleichmäßig verteilen zu können -->
-    <div id="apps" class="w3-content">
-        <div class="w3-row">
-
-            <?php foreach ($centerpanels as $centerpanel) { ?>
-                <a class="" href="<?= $centerpanel[0] ?>">
-                    <div class="w3-col <?= $centerpanel[2] ?> w3-round-xxlarge w3-hover-opacity w3-display-container centerpanels">
-                        <div class="w3-display-middle w3-large w3-center">
-                            <?= $centerpanel[1] ?>
-                        </div>
-                    </div>
-                </a>
-            <?php } //end foreach?>
-
-        </div> <!-- w3-row -->
-    </div> <!-- w3-apps -->
-</div> <!-- w3-messen -->
-
-<script>
-    //setzt die Margin der centerpanels-Quadrate so, dass sie immer gleich verteilt sind
-    window.addEventListener("resize", centerpanels_anordnung);
-    centerpanels_anordnung();
-</script>
+<div class="flex-container">
+    <?php foreach ($panels as $panel): ?>
+        <a class="no flex-item <?= $panel[2] ?> w3-round-xlarge w3-hover-opacity" href="<?= $panel[0] ?>">
+            <?= $panel[1] ?>
+        </a>
+    <?php endforeach; ?>
+</div>
 
 <?php include '../../templates/footer.tmp.php'; ?>
-

--- a/public/teamcenter/tc_start.php
+++ b/public/teamcenter/tc_start.php
@@ -5,40 +5,22 @@
 require_once '../../init.php';
 require_once '../../logic/session_team.logic.php'; //auth
 
-$centerpanels = Nav::get_tc_start();
+$panels = Nav::get_tc_start();
+
 Html::info("In euren " . Html::link(Env::BASE_URL . "/teamcenter/tc_teamdaten.php", "Teamdaten")
-    . " könnt ihr mögliche Bonus-Freilose für frühzeitig gesetzte Freilose und angemeldete Turniere sehen.", esc:false);
+    . " könnt ihr mögliche Bonus-Freilose für frühzeitig gesetzte Freilose und angemeldete Turniere sehen.", esc: false);
 /////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////LAYOUT///////////////////////////////////
 /////////////////////////////////////////////////////////////////////////////
-Html::$page_width = "660px";
 include '../../templates/header.tmp.php'; ?>
 
 <h1 class='w3-center w3-text-primary'>Hallo <?= $_SESSION['logins']['team']['name'] ?>!</h1>
-<div id="messen" class="">
-    <!-- Misst die Fensterbreite des Browsers, um die Centerpanels gleichmäßig verteilen zu können -->
-    <div id="apps" class="w3-content">
-        <div class="w3-row">
-
-            <?php foreach ($centerpanels as $centerpanel) { ?>
-                <a class="" href="<?= $centerpanel[0] ?>">
-                    <div class="w3-col <?= $centerpanel[2] ?> w3-round-xxlarge w3-hover-opacity w3-display-container centerpanels">
-                        <div class="w3-display-middle w3-large w3-center">
-                            <?= $centerpanel[1] ?>
-                        </div>
-                    </div>
-                </a>
-            <?php } //end foreach?>
-
-        </div> <!-- w3-row -->
-    </div> <!-- apps -->
-</div> <!-- messen -->
-
-<script>
-    //setzt die Margin der centerpanels-Quadrate so, dass sie immer gleich verteilt sind
-    window.addEventListener("resize", centerpanels_anordnung);
-    centerpanels_anordnung();
-</script>
+<div class="flex-container">
+    <?php foreach ($panels as $panel): ?>
+        <a class="no flex-item <?= $panel[2] ?> w3-round-xlarge w3-hover-opacity" href="<?= $panel[0] ?>">
+            <?= $panel[1] ?>
+        </a>
+    <?php endforeach; ?>
+</div>
 
 <?php include '../../templates/footer.tmp.php'; ?>
-


### PR DESCRIPTION
Die bisherige Erstellung der Grid-Darstellung erfolgte über eine Berechnung mittels JS und Manipulation beim User. Stattdessen habe ich die Flex-Darstellung verwendet. Hier können Problemlos neue Fehler in der Navigation aufgenommen werden, da diese dann entsprechend ergänzt werden.

Die Downloads im Ligacenter wurden in einem weiteren Grid aufgenommen.

- Getestet wurde es im Teamcenter und im Ligacenter. Im ÖA-Center keine Tests und im Schiri-Center scheinbar kein Grid?
- Funktioniet auf Desktop und auch Mobil.