### PR TITLE
Hotfix: Falsche Turniere in Meisterschaftstabelle

### DIFF
--- a/classes/tabelle.class.php
+++ b/classes/tabelle.class.php
@@ -221,7 +221,7 @@ class Tabelle
 
         $sql = "
             WITH tournaments as (
-                SELECT te.team_id, teams.teamname, te.turnier_id, tl.datum, te.ergebnis, td.ort, tl.tblock, te.platz, dense_rank() over (PARTITION BY te.team_id order by te.ergebnis) AS `rank`
+                SELECT te.team_id, teams.teamname, te.turnier_id, tl.datum, te.ergebnis, td.ort, tl.tblock, te.platz, dense_rank() over (PARTITION BY te.team_id order by te.ergebnis DESC) AS `rank`
                 FROM turniere_ergebnisse te
                 INNER JOIN turniere_liga tl ON tl.turnier_id = te.turnier_id
                 INNER JOIN teams_liga teams ON teams.team_id = te.team_id


### PR DESCRIPTION
In der Meisteschaftstabelle wurden durch fehlerhafte Sortierung nicht die besten fünf, sondern die schlechtesten fünf Turniere ausgegeben. Das wird hiermit korrigiert.