### PR TITLE
Nichtligaturniere aus Statistiken entfernt

### DIFF
--- a/public/liga/neues.php
+++ b/public/liga/neues.php
@@ -22,8 +22,8 @@ $last_turniere = array_slice($turniere, 0, 4);
 $colors = ["w3-text-tertiary", "w3-text-grey", "w3-text-brown"];
 $icons = ["looks_one", "looks_two", "looks_3"];
 
-$statistik['max_gew'] = Stats::get_gew_spiele_team();
-$statistik['max_turniere'] = Stats::get_turniere_team();
+$statistik['max_gew'] = Stats::get_gew_spiele_team(limit: 3);
+$statistik['max_turniere'] = Stats::get_turniere_team(limit: 3);
 $statistik['ges_tore'] = Stats::get_tore_anzahl();
 $statistik['ges_spiele'] = Stats::get_spiele_anzahl();
 $statistik['spielminuten'] = Stats::get_spielminuten_anzahl();

--- a/public/liga/statistik.php
+++ b/public/liga/statistik.php
@@ -4,10 +4,10 @@
 /////////////////////////////////////////////////////////////////////////////
 require_once '../../init.php';
 
-$max_turniere = Stats::get_turniere_team(limit: 999);
-$max_gew = Stats::get_gew_spiele_team(limit: 999);
-$max_ausrichter = Stats::get_max_ausrichter(limit: 999);
-$max_turnierorte = Stats::get_max_turnierorte(limit: 999);
+$max_turniere = Stats::get_turniere_team();
+$max_gew = Stats::get_gew_spiele_team();
+$max_ausrichter = Stats::get_max_ausrichter();
+$max_turnierorte = Stats::get_max_turnierorte();
 
 $gespielte_turniere = count(nTurnier::get_turniere_ergebnis($asc = false));
 $anstehende_turniere = count(nTurnier::get_turniere_kommend());


### PR DESCRIPTION
Bisher wurden NL-Turniere mit in die Statistik aufgenommen, wenn dort Ligateams hinterlegt gewesen sind. Dies wurde geändert. Zudem werden die Anzahl der Spiele und Siege sofort abgebildet, auch wenn die Ergebnisse noch nicht eingetragen gewesen sind.

Fix für #134 