### PR TITLE
Sammlung an neuen / geänderten Inhalten auf der Webseite

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ services:
       - ./logic:/var/www/html/logic
       - ./public:/var/www/html/public
       - ./src:/var/www/html/src
+      - ./system:/var/www/html/system
       - ./templates:/var/www/html/templates
       - ./init.php:/var/www/html/init.php
       - ./env.php:/var/www/html/env.php

--- a/public/liga/archiv.php
+++ b/public/liga/archiv.php
@@ -12,7 +12,10 @@ Html::$content = 'Hier kann man die Ergebnisse und Tabellen seit der ersten Sais
 include '../../templates/header.tmp.php';
 ?>
 
-    <h1 class="w3-text-primary">Saison-Archiv der Deutschen Einradhockeyliga</h1>
+<h1 class="w3-text-primary">Saison-Archiv der Deutschen Einradhockeyliga</h1>
+    <p><?= Html::link('ergebnisse.php?saison=30', 'Turniere der Saison 2024/2025') ?></p>
+    <p><?= HTML::link('tabelle.php?saison=30', 'Tabelle der Saison 2024/2025') ?></p>
+    <hr>
     <p><?= Html::link('ergebnisse.php?saison=29', 'Turniere der Saison 2023/2024') ?></p>
     <p><?= HTML::link('tabelle.php?saison=29', 'Tabelle der Saison 2023/2024') ?></p>
     <hr>

--- a/public/liga/ergebnisse.php
+++ b/public/liga/ergebnisse.php
@@ -2,10 +2,8 @@
 /////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////LOGIK////////////////////////////////////
 /////////////////////////////////////////////////////////////////////////////
+
 use App\Repository\Turnier\TurnierRepository;
-use App\Service\Turnier\TurnierLinks;
-use App\Service\Turnier\TurnierService;
-use App\Service\Turnier\TurnierSnippets;
 
 require_once '../../init.php';
 
@@ -15,10 +13,6 @@ $turniere = TurnierRepository::getErgebnisTurniere(saison: $saison);
 if (empty($turniere)) {
     Html::info("Es wurden keine Turnierergebnisse der Saison " . Html::get_saison_string($saison) . " eingetragen");
 }
-//Farbe für die Plätze auf dem Turnier
-$color[0] = "w3-text-tertiary";
-$color[1] = "w3-text-grey";
-$color[2] = "w3-text-brown";
 
 //Turnierreport Icon
 $icon = (isset($_SESSION['logins']['team'])) ? 'article' : 'lock';
@@ -28,97 +22,44 @@ $icon = (isset($_SESSION['logins']['team'])) ? 'article' : 'lock';
 /////////////////////////////////////////////////////////////////////////////
 Html::$titel = "Turnierergebnisse " . Html::get_saison_string($saison) . " | Deutsche Einradhockeyliga";
 Html::$content = 'Hier kann man die Ergebnisse und Tabellen der Saison ' . Html::get_saison_string($saison) . ' sehen.';
-include '../../templates/header.tmp.php'; ?>
+include '../../templates/header.tmp.php';
 
-    <!--Javascript für Suchfunktion-->
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
-    <script>
-        //Turnierergebnisse filtern
-        $(document).ready(function () {
-            $("#myInput").on("keyup", function () {
-                var value = $(this).val().toLowerCase();
-                $("#myDIV section").filter(function () {
-                    $(this).toggle($(this).text().toLowerCase().indexOf(value) > -1)
-                });
+?>
+
+<!--Javascript für Suchfunktion-->
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
+<script>
+    // Turnierergebnisse filtern
+    $(document).ready(function () {
+        $("#myInput").on("keyup", function () {
+            var value = $(this).val().toLowerCase();
+            $("#myDIV section").filter(function () {
+                $(this).toggle($(this).text().toLowerCase().indexOf(value) > -1)
             });
         });
-    </script>
+    });
+</script>
 
-    <!--Überschrift-->
-    <h1 class="w3-text-primary">
-        <?= Html::icon("emoji_events", tag: "h1") ?> Turnierergebnisse
-        <br>
-        <span class="w3-text-grey">
-            Saison <?= Html::get_saison_string($saison) ?>
-        </span>
-    </h1>
+<!--Überschrift-->
+<h1 class="w3-text-primary">Ergebnisse</h1>
+<p class="w3-border-top w3-border-grey w3-text-grey">Saison <?=Html::get_saison_string($saison)?></p>
 
-    <!-- Ergebnis suchen -->
-    <div class="w3-section w3-text-grey w3-border-bottom" style="width: 250px;">
-        <label for="myInput" class="w3-left"><?= Html::icon("search", 70) ?></label>
-        <input id="myInput"
-               class='w3-padding w3-border-0'
-               style="width: 225px; display: inline-block;"
-               type="text"
-               placeholder="Ergebnis suchen"
-        >
-    </div>
+<!-- Ergebnis suchen -->
+<div class="w3-section w3-text-grey w3-border-bottom" style="width: 250px;">
+    <label for="myInput" class="w3-left"><?= Html::icon("search", 70) ?></label>
+    <input id="myInput"
+            class='w3-padding w3-border-0'
+            style="width: 225px; display: inline-block;"
+            type="text"
+            placeholder="Ergebnis suchen"
+    >
+</div>
 
-    <!--Turnierergebnisse-->
-    <div id="myDIV">
-        <?php foreach ($turniere as $turnier_id => $turnier) { ?>
-            <section class="w3-section" id="<?= $turnier_id ?>">
-                <h3>
-                    <?= TurnierSnippets::datumOrtBlock($turnier) ?>
-                    <br>
-                    <span class="<?= $turnier->isFinalTurnier() ? "w3-text-secondary" : "w3-text-grey" ?>">
-                        <?= $turnier->getName() ?? '' ?>
-                    </span>
-                </h3>
-                <div class="w3-responsive w3-card-4">
-                    <table class="w3-table w3-centered w3-striped w3-leftbar w3-border-tertiary">
-                        <tr class="w3-primary">
-                            <th>
-                                <?= Html::icon("bar_chart") ?>
-                                <br>Platz
-                            </th>
-                            <th>
-                                <?= Html::icon("group") ?>
-                                <br>Team
-                            </th>
-                            <th class="w3-center">
-                                <?= Html::icon("emoji_events") ?>
-                                <br>Ergebnis
-                            </th>
-                        </tr>
-                        <?php foreach ($turnier->getErgebnis() as $key => $ergebnis): ?>
-                            <tr class="<?= $color[$key] ?? '' ?>">
-                                <td><?= $ergebnis->getPlatz() ?></td>
-                                <td style="white-space: nowrap"><?= $ergebnis->getTeam()->getName() ?></td>
-                                <td><?= $ergebnis->getErgebnis() ?: '-' ?></td>
-                            </tr>
-                        <?php endforeach; ?>
-                    </table>
-                </div>
-                <?= TurnierService::hasNlTeamErgebnis($turnier)
-                    ? "<span class='w3-text-grey w3-small'>* Nichtligateam</span>"
-                    : "" ?>
-                <p>
-                    <?php if ($saison <= 25) { ?>
-                        <?= Html::link('archiv.php', 'Details', icon:'info') ?>
-                    <?php } else { ?>
-                        <span>
-                        <?= Html::link(TurnierLinks::spielplan($turnier), 'Spielergebnisse', icon:'info') ?>
-                        </span>
-                        <?= Html::link("../teamcenter/tc_turnier_report.php?turnier_id=" . $turnier->id(), 'Turnierreport', icon:$icon) ?>
-                        <?php if (isset($_SESSION['logins']['la'])) { ?>
-                            <?= Html::link("../ligacenter/lc_turnier_report.php?turnier_id=" . $turnier->id(), 'Turnierreport (Ligaausschuss)', icon:'article') ?>
-                            <?= Html::link("../ligacenter/lc_spielplan.php?turnier_id=" . $turnier->id(), 'Spielergebnisse verwalten (Ligaausschuss)', icon:'info') ?>
-                        <?php }//endif?>
-                    <?php }//end if?>
-                </p>
-            </section>
-        <?php } //end foreach?>
-    </div>
+<!-- Turnierergebnisse -->
+<div id="myDIV" class="ergebnisse-container">
+    <?php foreach ($turniere as $turnier_id => $turnier): ?>
+        <?php include '../../templates/turnier_ergebnis.tmp.php'; ?>
+    <?php endforeach; ?>
+</div>
 
 <?php include '../../templates/footer.tmp.php';

--- a/public/liga/turniere.php
+++ b/public/liga/turniere.php
@@ -38,14 +38,23 @@ include '../../templates/header.tmp.php';
         });
     </script>
 
-    <?php //include '../../templates/finalturniere22.tmp.php'; ?>
-
-    <h1 class="w3-text-primary">Turniere der Saison <?= Html::get_saison_string() ?></h1>
+    <h1 class="w3-text-primary">
+        <?= Html::icon("access_time", tag: "h1") ?> Kommende Turniere
+        <br>
+        <span class="w3-text-grey">
+            Saison <?= Html::get_saison_string() ?>
+        </span>
+    </h1>
 
     <!-- Turnier suchen -->
     <div class="w3-section w3-text-grey w3-border-bottom" style="width: 250px;">
-        <label for="myInput"><?= Html::icon("search") ?></label>
-        <input id="myInput" class='w3-padding w3-border-0' style="width: 225px;" type="text" placeholder="Turnier suchen">
+        <label for="myInput" class="w3-left"><?= Html::icon("search", 70) ?></label>
+        <input id="myInput"
+               class='w3-padding w3-border-0'
+               style="width: 225px; display: inline-block;"
+               type="text"
+               placeholder="Turnier suchen"
+        >
     </div>
 
     <!-- zu durchsuchendes div -->

--- a/src/Repository/Turnier/TurnierRepository.php
+++ b/src/Repository/Turnier/TurnierRepository.php
@@ -118,7 +118,7 @@ class TurnierRepository
             ->leftJoin('l.team', 'team')
             ->where('t.saison = :saison')
             ->andWhere('t.phase = :phase')
-            ->orderBy('t.datum', 'asc')
+            ->orderBy('t.datum', 'desc')
             ->setParameter('saison', $saison)
             ->setParameter('phase', "ergebnis")
         ;

--- a/templates/turnier_ergebnis.tmp.php
+++ b/templates/turnier_ergebnis.tmp.php
@@ -1,0 +1,50 @@
+<?php
+
+use App\Service\Turnier\TurnierSnippets;
+use App\Service\Turnier\TurnierService;
+use App\Service\Turnier\TurnierLinks;
+
+?>
+
+<section id="<?= $turnier_id ?>" style="padding-top: 16px; padding-bottom: 32px;">
+    <div class="w3-row">
+        <div class="w3-col">
+            <h3><?= TurnierSnippets::datumOrtBlock($turnier) ?></h3>
+        </div>
+    </div>
+    
+    <?php if (!empty($turnier->getName())): ?>
+        <div class="w3-row w3-padding-8 <?= $turnier->isFinalTurnier() ? "w3-tertiary" : "w3-primary" ?>">
+            <div class="w3-col w3-center">
+                <b><?= $turnier->getName() ?></b>
+            </div>
+        </div>
+    <?php endif; ?>
+
+    <!-- Header fuer die Ergebnis-Tabelle -->
+    <div class="w3-row w3-primary">
+        <div class="w3-col w3-left w3-padding-8 w3-right-align" style="width: 36px;">#</div>
+        <div class="w3-col w3-right w3-padding-8 w3-right-align" style="width: 80px;">Punkte</div>
+        <div class="w3-rest w3-padding-8">Team</div>
+    </div>
+
+    <!-- Team-Ergebnisse in der Ergebnis-Tabelle -->
+    <?php foreach ($turnier->getErgebnis() as $key => $ergebnis): ?>
+        <div class="w3-row w3-border-bottom w3-border-grey <?= $key % 2 == 0 ? '' : 'w3-light-grey' ?>">
+            <div class="w3-col w3-left w3-padding-8 w3-right-align" style="width: 36px"><?= $ergebnis->getPlatz() ?></div>
+            <div class="w3-col w3-right w3-padding-8 w3-right-align" style="width: 80px;"><?= $ergebnis->getErgebnis() ? number_format($ergebnis->getErgebnis() ?: 0, 0, ",", ".") : '-' ?></div>
+            <div class="w3-rest w3-padding-8"><?= $ergebnis->getTeam()->getName() ?></div>
+        </div>                   
+    <?php endforeach; ?>
+
+    <div class="w3-row">
+        <div class="w3-col w3-padding-8 w3-left-align w3-text-grey" style="width: 150px;">
+            <?php if (TurnierService::hasNlTeamErgebnis($turnier)): ?>
+                * Nichtligateam
+            <?php endif; ?>
+        </div>
+        <div class="w3-rest w3-padding-8 w3-right-align">
+            <?= Html::link(TurnierLinks::spielplan($turnier), 'Spielergebnisse', icon:'open_in_new') ?>
+        </div>
+    </div>
+</section>


### PR DESCRIPTION
Nimmt alle Änderungen vor, die in #241 gesammelt werden:
- Im Archiv sind nun die Turniere und die Tabelle der Saison 30 gelistet
- Die Reihenfolge der Turniere auf der Ergebnisseite ist geändert. Das neuste Turnier findet sich nun an erster Stelle

Darüber hinaus:
- Für die Turniere- und Eregbnis-Seite wurden die Seitentitel vereinheitlicht
- Die Ergebnisse auf der Ergebnis-Seite werden nun anders dargestellt
- Auf der Ergebnisseite wurden die Links des LA und der Teams zum Center (Turnierreport, ...) entfernt ( #244 )

