### PR TITLE
Anpassung der Faktoren für die unterschiedlichen Turniere

### DIFF
--- a/classes/spielplan.class.php
+++ b/classes/spielplan.class.php
@@ -564,10 +564,43 @@ class Spielplan
                 // Normales Ligateam
                 $wert = $this->teamliste[$team_id]->wertigkeit;
             }
-            $werte[] = $wert;
-            $ligapunkte += $wert;
-            $this->platzierungstabelle[$team_id]['ligapunkte'] = round($ligapunkte * 6 / $this->details['faktor']);
+            $this->platzierungstabelle[$team_id]['wertigkeit'] = $wert;
         }
     }
 
+    /**
+     * Berechnet und fügt die Ligapunkte in die Platzierungstabelle ein.
+     */
+    public function set_ligapunkte(): void
+    {
+        $plaetze = $this->details['plaetze'];
+        
+        // Invertiere die Tabelle um die Punkte addieren zu können
+        $reverse_tabelle = array_reverse($this->platzierungstabelle, true);
+        if ($plaetze > 3) {
+            // Addiere die Wertigkeiten der Teams zu den Ligapunkten und verrechne den Faktor
+            $ligapunkte = 0;
+            foreach ($this->reverse_tabelle as $team_id => $eintrag) {
+                $ligapunkte += $this->platzierungstabelle[$team_id]['wertigkeit']
+                $this->platzierungstabelle[$team_id]['ligapunkte'] = round($ligapunkte * $this->details['faktor']);
+            }
+        
+        } else {
+            // Erhalte die Wertigkeit des erstplatzierten Teams
+            $wertung = 0;
+            foreach ($this->reverse_tabelle as $team_id => $eintrag) {
+                $wertung = $this->platzierungstabelle[$team_id]['wertigkeit']
+            }
+            
+            // Berechne die Punkte für jedes Team anhand der Wertigkeit des ersten Teams
+            $counter = 0;
+            $faktoren = [1.5, 0.75, 0.5];
+            foreach ($this->reverse_tabelle as $team_id => $eintrag) {
+                $this->platzierungstabelle[$team_id]['ligapunkte'] = round($wertung * $faktoren[$counter]);
+                $counter++;
+            }
+        }
+
+    }
 }
+

--- a/classes/spielplan_jgj.class.php
+++ b/classes/spielplan_jgj.class.php
@@ -37,6 +37,7 @@ final class Spielplan_JgJ extends Spielplan {
 
         if (!$skip_init) {
             $this->set_wertigkeiten();
+            $this->set_ligapunkte();
         }
 
         if (!empty($this->penaltys['kontrolle']) && $this->check_turnier_beendet()) {


### PR DESCRIPTION
- Implementiert die Anforderung für #212 
- Berücksichtigt die Faktoren für die 3er Turniere

Für die Umsetzung sind folgende Änderungen an der Datenbank notenwendig:
```sql
-- Die Reihenfolge der Befehle ist entscheidend
DELETE FROM `spielplan_details` WHERE `spielplan` = 'euhc_a';
DELETE FROM `spielplan_details` WHERE `spielplan` = 'euhc_b';
ALTER TABLE `spielplan_details` CHANGE `faktor` `faktor` TINYINT(4) NULL;
UPDATE `spielplan_details` SET `faktor` = NULL WHERE `plaetze` = 12 OR `plaetze` = 3;
ALTER TABLE `spielplan_details` CHANGE `faktor` `faktor` DECIMAL(3,2) NULL DEFAULT NULL;
UPDATE `spielplan_details` SET `faktor` = 6/`faktor`;
UPDATE `spielplan_details` SET `faktor` = 1.30 WHERE `plaetze` = 4;
```