### PR TITLE
Updates für Docker und Docker Compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,5 +34,7 @@ RUN composer install --no-dev --optimize-autoloader
 # Expose port 80 for web traffic
 EXPOSE 80
 
-# Start the Apache server
-CMD ["apache2-foreground"]
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
+ENTRYPOINT ["docker-entrypoint.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ services:
       - ./public:/var/www/html/public
       - ./src:/var/www/html/src
       - ./system:/var/www/html/system
+      - ./cache/proxy:/var/www/html/cache/proxy
       - ./templates:/var/www/html/templates
       - ./init.php:/var/www/html/init.php
       - ./env.php:/var/www/html/env.php

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+
+composer dump-autoload --optimize
+php bin/doctrine orm:clear-cache:metadata || true
+php bin/doctrine orm:clear-cache:query || true
+php bin/doctrine orm:generate-proxies || true
+
+# Starte Apache (das Original-CMD)
+exec apache2-foreground


### PR DESCRIPTION
- Beim Starten der Container werden nun die Doctrine Caches gelöscht und die Proxies neu erzeugt
- Ein Permission-Fehler für die Proxies wurde behoben
- Wird die composer.lock aktualisiert, dann muss das Image neu gebaut werden! Alternativ: Man könnte jedes Mal ein Update laufen lassen. Dann muss nicht geprüft werden, ob ein neuer lock vorliegt...