### PR TITLE
Berechnung des Turniergebnisses für 3er Turniere

### DIFF
--- a/classes/spielplan_jgj.class.php
+++ b/classes/spielplan_jgj.class.php
@@ -31,7 +31,7 @@ final class Spielplan_JgJ extends Spielplan {
     {
         parent:: __construct($turnier);
 
-        $this->tore_tabelle = $this->get_toretabelle($penaltys);
+        $this->tore_tabelle = $this->get_torematrix($penaltys);
         $this->turnier_tabelle = self::get_sorted_turniertabelle($this->tore_tabelle);
         $this->set_platzierungen($this->tore_tabelle);
 
@@ -48,10 +48,10 @@ final class Spielplan_JgJ extends Spielplan {
     /**
      * Sortiert die Turniertabelle
      *
-     * @param array $tore_tabelle Toretabelle aus get_toretabelle
+     * @param array $tore_tabelle Toretabelle aus get_torematrix()
      * @return array Sortierte Turniertabelle
      */
-    public static function get_sorted_turniertabelle(array $tore_tabelle): array
+    public static function get_sorted_turniertabelle(array $tore_matrix): array
     {
         $sort_function = static function ($ergebnis_a, $ergebnis_b) {
             if ($ergebnis_a['punkte'] > $ergebnis_b['punkte']) return -1;
@@ -69,7 +69,7 @@ final class Spielplan_JgJ extends Spielplan {
             return -1; // Team welches links steht kommt nach oben, also das Team mit der höheren Rangtabellenwertung
         };
 
-        $turnier_tabelle = self::get_turniertabelle($tore_tabelle);
+        $turnier_tabelle = self::get_turniertabelle($tore_matrix);
         uasort($turnier_tabelle, $sort_function);
         return $turnier_tabelle;
     }

--- a/public/liga/spielplan.php
+++ b/public/liga/spielplan.php
@@ -16,9 +16,7 @@ include '../../templates/header.tmp.php';
 include '../../templates/spielplan/spielplan_titel.tmp.php';
 include '../../templates/spielplan/spielplan_teamliste.tmp.php'; // Teamliste
 include '../../templates/spielplan/spielplan_spiele.tmp.php'; // Spiele
-if ($spielplan->anzahl_teams != 3) {
-    include '../../templates/spielplan/spielplan_turniertabelle.tmp.php'; // Abschlusstabelle
-    include '../../templates/spielplan/spielplan_direkter_vergleich.tmp.php'; // Direkter Vergleich Tabellen
-}
+include '../../templates/spielplan/spielplan_turniertabelle.tmp.php'; // Abschlusstabelle
+include '../../templates/spielplan/spielplan_direkter_vergleich.tmp.php'; // Direkter Vergleich Tabellen
 include '../../templates/footer.tmp.php';
 


### PR DESCRIPTION
solves #160 

- Es ist nun möglich, mehrere Spiele für zwei Teams zu berücksichtigen
- Die Spiele werden nun in einem Array aufgenommen und durchlaufen

Ich konnte keine Fehler in der Berechnung des direkten Vergleichs finden.