### PR TITLE
Hotfix: Spielpläne können nicht angezeigt werden

### DIFF
--- a/classes/nturnier.class.php
+++ b/classes/nturnier.class.php
@@ -195,6 +195,14 @@ class nTurnier
     }
 
     /**
+     * @return int
+     */
+    public function get_saison(): int
+    {
+        return $this->saison;
+    }
+
+    /**
      * @return string
      */
     public function get_ort(): string

--- a/classes/team.class.php
+++ b/classes/team.class.php
@@ -330,6 +330,16 @@ class Team
     }
 
     /**
+     * Gibt die Teamwertigkeit
+     * 
+     * @return null|int
+     */
+    public function get_wertigkeit(): null|int
+    {
+        return $this->wertigkeit;
+    }
+
+    /**
      * Setzt die Wertigkeit vor dem benannten Spieltag
      * 
      * @param int $spieltag


### PR DESCRIPTION
Die Wertigkeiten der Teams konnten nicht mehr festgestellt werden. Außerdem konnte ein Turnier nicht mehr mitteilen, in welcher Saison es war.