### PR TITLE
Anpassungen am Mailversand nach Turnieröffnung

### DIFF
--- a/src/Event/Turnier/nLigaBot.php
+++ b/src/Event/Turnier/nLigaBot.php
@@ -192,7 +192,7 @@ class nLigaBot
         foreach (self::$gelosteTurniere as $turnier) {
             if($turnier->isSofortOeffnen()) {
                 TurnierService::blockOeffnen($turnier);
-                TurnierService::setzListeAuffuellen($turnier, false);
+                TurnierService::setzListeAuffuellen($turnier);
             }
         }
 


### PR DESCRIPTION
Wurde ein Turnier durch den Ligabot sofort geöffnet, dann haben Teams eine Mail über ihre Position der Liste erhalten. Ist ein Tunier im Anschluss sofort geöffnet worden und ein Team dadurch auf die Setzliste gekommen, dann erhielt es diese Information NICHT.

Das ist hiermit nun behoben. Die Mails werden versendet und das Team erhält nun zwei Mails (Setzen auf Warteliste, Setzen auf Setzliste).