### PR TITLE
Zeitpunkt der Turniererstellung geändert

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "mpdf/mpdf": "v8.2.5",
         "gregwar/captcha": "v1.3.0",
         "doctrine/orm": "3.4.3",
-        "symfony/cache": "v7.3.1",
+        "symfony/cache": "v7.4.12",
         "jenssegers/date": "v4.0.0",
         "spatie/array-to-xml": "3.4.0",
         "phpoffice/phpspreadsheet": "5.7.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bc7182f30f48e1c6a272e709e812e480",
+    "content-hash": "33b4eb9340ab97df06ebd313fb359b39",
     "packages": [
         {
             "name": "carbonphp/carbon-doctrine-types",
@@ -2252,16 +2252,16 @@
         },
         {
             "name": "symfony/cache",
-            "version": "v7.3.1",
+            "version": "v7.4.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/cache.git",
-                "reference": "a7c6caa9d6113cebfb3020b427bcb021ebfdfc9e"
+                "reference": "902d621e0b6ef0ebeaa133770b5c339a19328589"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/cache/zipball/a7c6caa9d6113cebfb3020b427bcb021ebfdfc9e",
-                "reference": "a7c6caa9d6113cebfb3020b427bcb021ebfdfc9e",
+                "url": "https://api.github.com/repos/symfony/cache/zipball/902d621e0b6ef0ebeaa133770b5c339a19328589",
+                "reference": "902d621e0b6ef0ebeaa133770b5c339a19328589",
                 "shasum": ""
             },
             "require": {
@@ -2269,12 +2269,14 @@
                 "psr/cache": "^2.0|^3.0",
                 "psr/log": "^1.1|^2|^3",
                 "symfony/cache-contracts": "^3.6",
-                "symfony/deprecation-contracts": "^2.5|^3.0",
+                "symfony/deprecation-contracts": "^2.5|^3",
                 "symfony/service-contracts": "^2.5|^3",
-                "symfony/var-exporter": "^6.4|^7.0"
+                "symfony/var-exporter": "^6.4|^7.0|^8.0"
             },
             "conflict": {
                 "doctrine/dbal": "<3.6",
+                "ext-redis": "<6.1",
+                "ext-relay": "<0.12.1",
                 "symfony/dependency-injection": "<6.4",
                 "symfony/http-kernel": "<6.4",
                 "symfony/var-dumper": "<6.4"
@@ -2289,13 +2291,13 @@
                 "doctrine/dbal": "^3.6|^4",
                 "predis/predis": "^1.1|^2.0",
                 "psr/simple-cache": "^1.0|^2.0|^3.0",
-                "symfony/clock": "^6.4|^7.0",
-                "symfony/config": "^6.4|^7.0",
-                "symfony/dependency-injection": "^6.4|^7.0",
-                "symfony/filesystem": "^6.4|^7.0",
-                "symfony/http-kernel": "^6.4|^7.0",
-                "symfony/messenger": "^6.4|^7.0",
-                "symfony/var-dumper": "^6.4|^7.0"
+                "symfony/clock": "^6.4|^7.0|^8.0",
+                "symfony/config": "^6.4|^7.0|^8.0",
+                "symfony/dependency-injection": "^6.4|^7.0|^8.0",
+                "symfony/filesystem": "^6.4|^7.0|^8.0",
+                "symfony/http-kernel": "^6.4|^7.0|^8.0",
+                "symfony/messenger": "^6.4|^7.0|^8.0",
+                "symfony/var-dumper": "^6.4|^7.0|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -2330,7 +2332,7 @@
                 "psr6"
             ],
             "support": {
-                "source": "https://github.com/symfony/cache/tree/v7.3.1"
+                "source": "https://github.com/symfony/cache/tree/v7.4.12"
             },
             "funding": [
                 {
@@ -2342,11 +2344,15 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-06-27T19:55:54+00:00"
+            "time": "2026-05-20T07:20:23+00:00"
         },
         {
             "name": "symfony/cache-contracts",

--- a/logic/spielplan.logic.php
+++ b/logic/spielplan.logic.php
@@ -1,5 +1,7 @@
 <?php
 
+use App\Repository\Turnier\TurnierRepository;
+
 $turnier_id = (int) @$_GET['turnier_id'];
 
 Spielplan_Final::routeToFinalSpielplan($turnier_id); // Todo, allgemeiner Router für spezialspielpläne?
@@ -16,4 +18,13 @@ if ($saison <= 30) {
     $spielplan = new Archiv_Spielplan_JgJ($turnier);
 } else {
     $spielplan = new Spielplan_JgJ($turnier);
+}
+
+// Ergebnis laden - falls vorhanden
+$turnier_entity = TurnierRepository::get()->turnier($turnier_id);
+$ergebnisse = $turnier_entity->getErgebnis();
+
+foreach ($ergebnisse as $ergebnis_id => $ergebnis) {
+    $team_id = $ergebnis->getTeam()->id();
+    $spielplan->platzierungstabelle[$team_id]['ligapunkte'] = $ergebnis->getErgebnis();
 }

--- a/public/cronjobs/spielplan_erstellen.php
+++ b/public/cronjobs/spielplan_erstellen.php
@@ -13,22 +13,28 @@ echo "Spieltag: " . $aktueller_spieltag . "<br>";
 $turniere = nTurnier::get_turniere_spieltag($aktueller_spieltag);
 
 foreach ($turniere as $turnier) {
-    # Check if dienstag vor dem Datum
     $datum_string = $turnier->get_datum();
     $datum_turnier = strtotime($datum_string);
     $aktuelles_datum = time();
     $absage_grund = "";
     $erstellen = true;
-    # Wenn heute Dienstag ist, dann einen Tag weiter gehen
+    
+    # Sollte heute Dienstag sein, dann schieben das Datum einmal nach vorne
     if (date("N", $aktuelles_datum) == 2) {
         $aktuelles_datum = strtotime("+1 day", $aktuelles_datum);
     }
-    # Check Dienstag zwischen morgen und dem Datum des Turnieres
+    
+    # Prüfe, ob noch zwei Dienstage zwischen dem Turnier und dem Ausgangstag liegen
+    $dienstag_counter = 0;
     while ($aktuelles_datum < $datum_turnier) {
         # Dienstag = 2. Wochentag
         if (date("N", $aktuelles_datum) == 2) {
-            $erstellen = false;
-            break;
+            $dienstag_counter++;
+
+            if ($dienstag_counter > 1) {
+                $erstellen = false;
+                break;
+            }
         }
         $aktuelles_datum = strtotime("+1 day", $aktuelles_datum);
     }

--- a/public/cronjobs/spielplan_erstellen.php
+++ b/public/cronjobs/spielplan_erstellen.php
@@ -18,12 +18,12 @@ foreach ($turniere as $turnier) {
     $aktuelles_datum = time();
     $absage_grund = "";
     $erstellen = true;
-    
+
     # Sollte heute Dienstag sein, dann schieben das Datum einmal nach vorne
     if (date("N", $aktuelles_datum) == 2) {
         $aktuelles_datum = strtotime("+1 day", $aktuelles_datum);
     }
-    
+
     # Prüfe, ob noch zwei Dienstage zwischen dem Turnier und dem Ausgangstag liegen
     $dienstag_counter = 0;
     while ($aktuelles_datum < $datum_turnier) {

--- a/tests/integration/StatsTest.php
+++ b/tests/integration/StatsTest.php
@@ -76,7 +76,7 @@ class StatsTest extends TestCase
             actual: $spieleranzahl["number"],
         );
         # Sechs Monate in die Zukunft
-        $spieleranzahl = Stats::get_aktuelle_spieler_anzahl(time() + 6 * 30 * 24 * 3600);
+        $spieleranzahl = Stats::get_aktuelle_spieler_anzahl(time() + 8 * 30 * 24 * 3600);
         $this->assertTrue(
             condition: \is_string($spieleranzahl["cutoff"]),
         );


### PR DESCRIPTION
- Die Erstellung des Spielplans wird um eine Woche nach Vorne verschoben.
- Es braucht keine Anpassungen an der eigentlichen Erstellung, da die Spielpkäne hard-coded in der DB sind. Sollte sich also die Reihenfolge der Teams ändern, ändert sich nicht der Spielplan!
- Außerdem werden - wenn vorhanden - die Turnierergebnisse aus der Ergebnis-Tabelle geladen. Sollten also die Ergebnisse später angepasst werden, dann werden die richtigen Ligapunkte abgetragen. Läuft das Turnier, dann werden die aus der Berechnung übertragen.

---
Löst #370,  #342 